### PR TITLE
Das sonar cloud upgrade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.0
+    ref: refs/tags/2.1.28
     endpoint: SkillsFundingAgency
 
 stages:


### PR DESCRIPTION
Upgrading seems to have had no adverse effects, when setting the parameter "ContinueOnVulnerablePackageScanError" to true:
https://dev.azure.com/sfa-gov-uk/Digital%20Apprenticeship%20Service/_build/results?buildId=810888&view=results
https://dev.azure.com/sfa-gov-uk/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-logs&releaseId=108757&environmentId=506410

"ContinueOnVulnerablePackageScanError" has been set to default (false) because application is on supported framework.